### PR TITLE
Upgraded constructors to no longer use deprecated format

### DIFF
--- a/client/src/Address.php
+++ b/client/src/Address.php
@@ -53,7 +53,7 @@ class Address {
 	 * @param country The country of the address.
 	 * @param zipCode The post/zip code of the address.
 	 */
-	function Address(
+	function __construct(
 		$recipient = array(),
 		$lines = array(),
 		$city = null, 

--- a/client/src/CertificationAuthority.php
+++ b/client/src/CertificationAuthority.php
@@ -35,7 +35,7 @@ class CertificationAuthority {
 	 *	null no registered identity is set.
 	 * @private
 	 */
-	function CertificationAuthority($description, $rid) {
+	function __construct($description, $rid) {
 		$this->m_description = $description;
 		$this->m_rid = $rid;
 		$this->m_publicKeys = array();

--- a/client/src/Client.php
+++ b/client/src/Client.php
@@ -181,7 +181,7 @@ class Client
 	/**
 	 * Constructs a Client and initialises variables.
 	 */
-	function Client() {
+	function __construct() {
 		$this->m_serverURLs = array();
 		$this->m_proxyHost = null;
 		$this->m_proxyPassword = null;

--- a/client/src/EmailAddress.php
+++ b/client/src/EmailAddress.php
@@ -27,7 +27,7 @@ class EmailAddress {
 	 * @param address The email address.
 	 * @param type The type of the email address.
 	 */
-	function EmailAddress($address, $type) {
+	function __construct($address, $type) {
 		$this->m_address = $address;
 		$this->m_type = $type;		
 	}

--- a/client/src/ExtendedProperty.php
+++ b/client/src/ExtendedProperty.php
@@ -25,7 +25,7 @@ class ExtendedProperty {
 	 * @param name The name of the extended property
 	 * @param value The value of the extended property
 	 */
-	function ExtendedProperty($name, $value) {
+	function __construct($name, $value) {
 		$this->m_name = $name;
 		$this->m_value = $value;
 	}

--- a/client/src/ICCTag.php
+++ b/client/src/ICCTag.php
@@ -42,7 +42,7 @@ class ICCTag {
 	 *	If only two arguments to this function are found the second is taken to be the value: ICCTag(id, value).
 	 *	If three arguments are found the second is taken as being the type, the third the value: ICCTag(id, type, value).
 	 */
-	function ICCTag($id, $type_or_value) {
+	function __construct($id, $type_or_value) {
 
 		$this->m_id = $id;
 

--- a/client/src/Name.php
+++ b/client/src/Name.php
@@ -39,7 +39,7 @@ class Name {
 	 * @param initials The initials of the persion.
 	 * @param lastName The last name of the persion.
 	 */
-	function Name(
+	function __construct(
 		$title = null, 
 		$firstName = null, 
 		$initials = null, 

--- a/client/src/PhoneNumber.php
+++ b/client/src/PhoneNumber.php
@@ -27,7 +27,7 @@ class PhoneNumber {
 	 * @param number The phone number
 	 * @param type The type of the phone number.
 	 */
-	function PhoneNumber($number, $type) {
+	function __construct($number, $type) {
 		$this->m_number = $number;
 		$this->m_type = $type;		
 	}

--- a/client/src/Product.php
+++ b/client/src/Product.php
@@ -81,7 +81,7 @@ class Product {
 	 * @param risk The risk of the product.
 	 * @param type The type of the product.
 	 */
-	function Product(
+	function __construct(
 		$amount,
 		$amountUnit,
 		$category,

--- a/client/src/PublicKey.php
+++ b/client/src/PublicKey.php
@@ -69,7 +69,7 @@ class PublicKey {
 	 *	If null no hash algorithm is set.
 	 * @private
 	 */
-	function PublicKey(
+	function __construct(
 		$index,
 		$hash,
 		$hashAlgorithm) {

--- a/client/src/Request.php
+++ b/client/src/Request.php
@@ -731,17 +731,17 @@ class CardEaseXML_Request {
 			($this->m_deliveryPhoneNumbers !== null && count($this->m_deliveryPhoneNumbers) !== 0))
 		{			
 			$writer->writeStartElement("Delivery");
-		
+
 			if ($this->m_deliveryAddress !== null && !$this->m_deliveryAddress->isEmpty())
 			{
 				$writer->writeStartElement("Address");
-				
+
 				$writer->writeAttributeString("format", "standard");
-				
+
 				if ($this->m_deliveryAddress->getRecipient() !== null)
 				{					
 					$recipient = $this->m_deliveryAddress->getRecipient();
-				
+
 					for ($id = 0; $id < count($recipient); $id++)
 					{
 						$writer->writeStartElement("Recipient");
@@ -749,14 +749,14 @@ class CardEaseXML_Request {
 						$writer->writeString($recipient[$id]);
 						$writer->writeEndElement(); // Recipient
 					}
-					
+
 					unset($recipient);
 				}
-				
+
 				if ($this->m_deliveryAddress->getLines() !== null)
 				{					
 					$lines = $this->m_deliveryAddress->getLines();
-				
+
 					for ($id = 0; $id < count($lines); $id++)
 					{
 						$writer->writeStartElement("Line");
@@ -764,110 +764,110 @@ class CardEaseXML_Request {
 						$writer->writeString($lines[$id]);
 						$writer->writeEndElement(); // Line
 					}
-					
+
 					unset($lines);
 				}
-				
+
 				if ($this->m_deliveryAddress->getCity() !== null)
 				{
 					$writer->writeElementString("City", $this->m_deliveryAddress->getCity());
 				}
-				
+
 				if ($this->m_deliveryAddress->getState() !== null)
 				{
 					$writer->writeElementString("State", $this->m_deliveryAddress->getState());
 				}
-				
+
 				if ($this->m_deliveryAddress->getZipCode() !== null)
 				{
 					$writer->writeElementString("ZipCode", $this->m_deliveryAddress->getZipCode());
 				}
-				
+
 				if ($this->m_deliveryAddress->getCountry() !== null)
 				{
 					$writer->writeElementString("Country", $this->m_deliveryAddress->getCountry());
 				}
-				
+
 				$writer->writeEndElement(); // Address
 			}
-			
+
 			// DeliveryName
 			if (($this->m_deliveryEmailAddresses !== null && count($this->m_deliveryEmailAddresses) !== 0) ||
 				($this->m_deliveryName !== null && !$this->m_deliveryName->isEmpty()) ||
 				($this->m_deliveryPhoneNumbers !== null && count($this->m_deliveryPhoneNumbers) !== 0))
 			{				
 				$writer->writeStartElement("Contact");
-				
+
 				if ($this->m_deliveryEmailAddresses !== null && count($this->m_deliveryEmailAddresses) !== 0)
 				{					
 					$writer->writeStartElement("EmailAddressList");
-					
+
 					for ($id = 0; $id < count($this->m_deliveryEmailAddresses); $id++)
 					{						
 						$emailAddress = $this->m_deliveryEmailAddresses[$id];
-					
+
 						$writer->writeStartElement("EmailAddress");
 						$writer->writeAttributeString("id", $id + 1);
 						$writer->writeAttributeString("type", $emailAddress->getType());
 						$writer->writeString($emailAddress->getAddress());
 						$writer->writeEndElement(); // EmailAddress
-						
+
 						unset($emailAddress);
 					}
-					
+
 					$writer->writeEndElement(); // EmailAddressList
 				}
-				
+
 				if ($this->m_deliveryName !== null && !$this->m_deliveryName->isEmpty())
 				{					
 					$writer->writeStartElement("Name");
-					
+
 					if ($this->m_deliveryName->getTitle() !== null)
 					{
 						$writer->writeElementString("Title", $this->m_deliveryName->getTitle());
 					}
-					
+
 					if ($this->m_deliveryName->getFirstName() !== null)
 					{
 						$writer->writeElementString("FirstName", $this->m_deliveryName->getFirstName());
 					}
-					
+
 					if ($this->m_deliveryName->getInitials() !== null)
 					{
 						$writer->writeElementString("Initials", $this->m_deliveryName->getInitials());
 					}
-					
+
 					if ($this->m_deliveryName->getLastName() !== null)
 					{
 						$writer->writeElementString("LastName", $this->m_deliveryName->getLastName());
 					}
-					
+
 					$writer->writeEndElement(); // Name
 				}
-				
+
 				if ($this->m_deliveryPhoneNumbers !== null && count($this->m_deliveryPhoneNumbers) !== 0)
 				{					
 					$writer->writeStartElement("PhoneNumberList");
-					
+
 					for ($id = 0; $id < count($this->m_deliveryPhoneNumbers); $id++)
 					{						
 						$phoneNumber = $this->m_deliveryPhoneNumbers[$id];
-					
+
 						$writer->writeStartElement("PhoneNumber");
 						$writer->writeAttributeString("id", $id + 1);
 						$writer->writeAttributeString("type", $phoneNumber->getType());
 						$writer->writeString($phoneNumber->getNumber());
 						$writer->writeEndElement(); // PhoneNumber
-						
+
 						unset($phoneNumber);
 					}
-					
+
 					$writer->writeEndElement(); // PhoneNumberList
 				}
-				
+
 				$writer->writeEndElement(); // Contact
 			}
-				
+
 			$writer->writeEndElement(); // Delivery
 		}
 
@@ -875,7 +875,7 @@ class CardEaseXML_Request {
 		if ($this->m_extendedProperties !== null && count($this->m_extendedProperties) !== 0)
 		{
 			$writer->writeStartElement("ExtendedPropertyList");
-			
+
 			foreach ($this->m_extendedProperties as $extendedProperty)
 			{
 				$writer->writeStartElement("ExtendedProperty");
@@ -883,7 +883,7 @@ class CardEaseXML_Request {
 				$writer->writeString($extendedProperty->getValue());
 				$writer->writeEndElement(); // ExtendedProperty
 			}
-			
+
 			$writer->writeEndElement(); // ExtendedPropertyList
 		}
 
@@ -894,18 +894,18 @@ class CardEaseXML_Request {
 			($this->m_invoicePhoneNumbers !== null && count($this->m_invoicePhoneNumbers) !== 0))
 		{			
 			$writer->writeStartElement("Invoice");
-			
+
 			// InvoiceAddress
 			if (($this->m_invoiceAddress !== null && !$this->m_invoiceAddress->isEmpty()))
 			{				
 				$writer->writeStartElement("Address");
-				
+
 				$writer->writeAttributeString("format", "standard");
-				
+
 				if ($this->m_invoiceAddress->getRecipient() !== null)
 				{					
 					$recipient = $this->m_invoiceAddress->getRecipient();
-				
+
 					for ($id = 0; $id < count($recipient); $id++)
 					{
 						$writer->writeStartElement("Recipient");
@@ -913,14 +913,14 @@ class CardEaseXML_Request {
 						$writer->writeString($recipient[$id]);
 						$writer->writeEndElement(); // Recipient
 					}
-					
+
 					unset($recipient);
 				}
-				
+
 				if ($this->m_invoiceAddress->getLines() !== null)
 				{					
 					$lines = $this->m_invoiceAddress->getLines();
-				
+
 					for ($id = 0; $id < count($lines); $id++)
 					{
 						$writer->writeStartElement("Line");
@@ -928,110 +928,110 @@ class CardEaseXML_Request {
 						$writer->writeString($lines[$id]);
 						$writer->writeEndElement(); // Line
 					}
-					
+
 					unset($lines);
 				}
-				
+
 				if ($this->m_invoiceAddress->getCity() !== null)
 				{
 					$writer->writeElementString("City", $this->m_invoiceAddress->getCity());
 				}
-				
+
 				if ($this->m_invoiceAddress->getState() !== null)
 				{
 					$writer->writeElementString("State", $this->m_invoiceAddress->getState());
 				}
-				
+
 				if ($this->m_invoiceAddress->getZipCode() !== null)
 				{
 					$writer->writeElementString("ZipCode", $this->m_invoiceAddress->getZipCode());
 				}
-				
+
 				if ($this->m_invoiceAddress->getCountry() !== null)
 				{
 					$writer->writeElementString("Country", $this->m_invoiceAddress->getCountry());
 				}
-				
+
 				$writer->writeEndElement(); // Address
 			}
-			
+
 			// InvoiceName
 			if (($this->m_invoiceEmailAddresses !== null && count($this->m_invoiceEmailAddresses) !== 0) ||
 				($this->m_invoiceName !== null && !$this->m_invoiceName->isEmpty()) ||
 				($this->m_invoicePhoneNumbers !== null && count($this->m_invoicePhoneNumbers) !== 0))
 			{				
 				$writer->writeStartElement("Contact");
-				
+
 				if ($this->m_invoiceEmailAddresses !== null && count($this->m_invoiceEmailAddresses) !== 0)
 				{					
 					$writer->writeStartElement("EmailAddressList");
-					
+
 					for ($id = 0; $id < count($this->m_invoiceEmailAddresses); $id++)
 					{						
 						$emailAddress = $this->m_invoiceEmailAddresses[$id];						
-					
+
 						$writer->writeStartElement("EmailAddress");
 						$writer->writeAttributeString("id", $id + 1);
 						$writer->writeAttributeString("type", $emailAddress->getType());
 						$writer->writeString($emailAddress->getAddress());
 						$writer->writeEndElement(); // EmailAddress
-						
+
 						unset($emailAddress);
 					}
-					
+
 					$writer->writeEndElement(); // EmailAddressList
 				}
-				
+
 				if ($this->m_invoiceName !== null && !$this->m_invoiceName->isEmpty())
 				{				
 					$writer->writeStartElement("Name");
-					
+
 					if ($this->m_invoiceName->getTitle() !== null)
 					{
 						$writer->writeElementString("Title", $this->m_invoiceName->getTitle());
 					}
-					
+
 					if ($this->m_invoiceName->getFirstName() !== null)
 					{
 						$writer->writeElementString("FirstName", $this->m_invoiceName->getFirstName());
 					}
-					
+
 					if ($this->m_invoiceName->getInitials() !== null)
 					{
 						$writer->writeElementString("Initials", $this->m_invoiceName->getInitials());
 					}
-					
+
 					if ($this->m_invoiceName->getLastName() !== null)
 					{
 						$writer->writeElementString("LastName", $this->m_invoiceName->getLastName());
 					}
-					
+
 					$writer->writeEndElement(); // Name
 				}
-				
+
 				if ($this->m_invoicePhoneNumbers !== null && count($this->m_invoicePhoneNumbers) !== 0)
 				{					
 					$writer->writeStartElement("PhoneNumberList");
-					
+
 					for ($id = 0; $id < count($this->m_invoicePhoneNumbers); $id++)
 					{						
 						$phoneNumber = $this->m_invoicePhoneNumbers[$id];						
-					
+
 						$writer->writeStartElement("PhoneNumber");
 						$writer->writeAttributeString("id", $id + 1);
 						$writer->writeAttributeString("type", $phoneNumber->getType());
 						$writer->writeString($phoneNumber->getNumber());
 						$writer->writeEndElement(); // PhoneNumber
-						
+
 						unset($phoneNumber);
 					}
-					
+
 					$writer->writeEndElement(); // PhoneNumbers
 				}
-				
+
 				$writer->writeEndElement(); // Contact
 			}
-			
+
 			$writer->writeEndElement(); // Invoice
 		}
 
@@ -1039,73 +1039,73 @@ class CardEaseXML_Request {
 		if ($this->m_products !== null && count($this->m_products) !== 0)
 		{			
 			$writer->writeStartElement("ProductList");
-			
+
 			for ($id = 0; $id < count($this->m_products); $id++)
 			{				
 				$writer->writeStartElement("Product");
 				$writer->writeAttributeString("id", $id + 1);
-				
+
 				$product = $this->m_products[$id];
-				
+
 				if ($product->getAmount() !== null)
 				{
 					$writer->writeStartElement("Amount");
-					
+
 					// Default is minor
 					if ($product->getAmountUnit() === AmountUnit_Major)
 					{
 						$writer->writeAttributeString("unit", "major");
 					}
-					
+
 					$writer->writeString($product->getAmount());
 					$writer->writeEndElement(); // Amount
 				}
-				
+
 				if ($product->getCategory() !== null)
 				{
 					$writer->writeElementString("Category", $product->getCategory());
 				}
-				
+
 				if ($product->getCode() !== null)
 				{
 					$writer->writeElementString("Code", $product->getCode());
 				}
-				
+
 				if ($product->getDescription() !== null)
 				{
 					$writer->writeElementString("Description", $product->getDescription());
 				}
-				
+
 				if ($product->getCurrencyCode() !== null)
 				{
 					$writer->writeElementString("CurrencyCode", $product->getCurrencyCode());
 				}
-				
+
 				if ($product->getName() !== null)
 				{
 					$writer->writeElementString("Name", $product->getName());
 				}
-				
+
 				if ($product->getQuantity() !== null)
 				{
 					$writer->writeElementString("Quantity", $product->getQuantity());
 				}
-				
+
 				if ($product->getRisk() !== null)
 				{
 					$writer->writeElementString("Risk", $product->getRisk());
 				}
-				
+
 				if ($product->getType() !== null)
 				{
 					$writer->writeElementString("Type", $product->getType());
 				}
-				
+
 				$writer->writeEndElement(); // Product
-				
+
 				unset($product);
 			}
-			
+
 			$writer->writeEndElement(); // ProductList			
 		}
 
@@ -1193,139 +1193,139 @@ class CardEaseXML_Request {
 				$this->m_track2 !== null || $this->m_pan !== null || $this->m_cardReference !== null)
 			{		
 				$writer->writeStartElement("CardDetails");
-	
+
 				if ($this->m_iccTags !== null && count($this->m_iccTags) !== 0)
 				{	
 					$writer->writeStartElement("ICC");
 					$writer->writeAttributeString("type", $this->m_iccType);
-	
+
 					foreach ($this->m_iccTags as $tag)
 					{	
 						if ($tag === null)
 						{
 							continue;
 						}
-	
+
 						$writer->writeStartElement("ICCTag");
 						$writer->writeAttributeString("tagid", $tag->getID());
-	
+
 						if ($tag->getType() === ICCTagValueType_String)
 						{
 							$writer->writeAttributeString("type", "string");
 						}
-	
+
 						$writer->writeString($tag->getValue());
 						$writer->writeEndElement(); // ICCTag
 					}
-	
+
 					$writer->writeEndElement(); // ICC
-	
+
 				} 
 				else if ($this->m_track2 !== null)
 				{	
 					$writer->writeStartElement("CAT");
-	
+
 					if ($this->m_iccFallback)
 					{
 						$writer->writeAttributeString("fallback", "true");
 					}
-	
+
 					if ($this->m_track1 !== null)
 					{
 						$writer->writeElementString("Track1", $this->m_track1);
 					}
-	
+
 					if ($this->m_track2 !== null)
 					{
 						$writer->writeElementString("Track2", $this->m_track2);
 					}
-	
+
 					if ($this->m_track3 !== null)
 					{
 						$writer->writeElementString("Track3", $this->m_track3);
 					}
-	
+
 					$writer->writeEndElement(); // CAT
-	
+
 				}
 				else if ($this->m_pan !== null || $this->m_cardReference !== null)
 				{	
 					$writer->writeStartElement("Manual");
-	
+
 					if ($this->m_manualType !== null)
 					{
 						$writer->writeAttributeString("type", $this->m_manualType);
 					}
-	
+
 					if ($this->m_cardReference !== null)
 					{
 						$writer->writeElementString("CardReference", $this->m_cardReference);
 					}
-					
+
 					if ($this->m_cardHash !== null)
 					{
 						$writer->writeElementString("CardHash", $this->m_cardHash);
 					}
-	
+
 					if ($this->m_pan !== null)
 					{
 						$writer->writeElementString("PAN", $this->m_pan);
 					}
-	
+
 					if ($this->m_expiryDate !== null)
 					{	
 						$writer->writeStartElement("ExpiryDate");
-	
+
 						if ($this->m_expiryDateFormat !== null)
 						{
 							$writer->writeAttributeString("format",	$this->m_expiryDateFormat);
 						}
-	
+
 						$writer->writeString($this->m_expiryDate);
 						$writer->writeEndElement(); // ExpiryDate
-	
+
 					}
-	
+
 					if ($this->m_startDate !== null)
 					{	
 						$writer->writeStartElement("StartDate");
-	
+
 						if ($this->m_startDateFormat !== null)
 						{
 							$writer->writeAttributeString("format", $this->m_startDateFormat);
 						}
-	
+
 						$writer->writeString($this->m_startDate);
 						$writer->writeEndElement(); // StartDate	
 					}
-	
+
 					if ($this->m_issueNumber !== null)
 					{
 						$writer->writeElementString("IssueNumber", $this->m_issueNumber);
 					}
-	
+
 					$writer->writeEndElement(); // Manual
 				}
-	
+
 				if ($this->m_address !== null || $this->m_csc !== null || $this->m_zipCode !== null)
 				{	
 					$writer->writeStartElement("AdditionalVerification");
-	
+
 					if ($this->m_address !== null)
 					{
 						$writer->writeElementString("Address", $this->m_address);
 					}
-	
+
 					if ($this->m_csc !== null)
 					{
 						$writer->writeElementString("CSC", $this->m_csc);
 					}
-	
+
 					if ($this->m_zipCode !== null)
 					{
 						$writer->writeElementString("Zip", $this->m_zipCode);
 					}
-	
+
 					$writer->writeEndElement(); // AdditionalVerification
 				}
 
@@ -1333,13 +1333,13 @@ class CardEaseXML_Request {
 				if ($this->m_cardHolderAddress !== null && !$this->m_cardHolderAddress->IsEmpty())
 				{					
 					$writer->writeStartElement("Address");
-					
+
 					$writer->writeAttributeString("format", "standard");
-					
+
 					if ($this->m_cardHolderAddress->getRecipient() !== null)
 					{						
 						$recipient = $this->m_cardHolderAddress->getRecipient();
-					
+
 						for ($id = 0; $id < count($recipient); $id++)
 						{
 							$writer->writeStartElement("Recipient");
@@ -1347,14 +1347,14 @@ class CardEaseXML_Request {
 							$writer->writeString($recipient[$id]);
 							$writer->writeEndElement(); // Recipient
 						}
-						
+
 						unset($recipient);
 					}
-					
+
 					if ($this->m_cardHolderAddress->getLines() !== null)
 					{						
 						$lines = $this->m_cardHolderAddress->getLines();
-					
+
 						for ($id = 0; $id < count($lines); $id++)
 						{
 							$writer->writeStartElement("Line");
@@ -1362,30 +1362,30 @@ class CardEaseXML_Request {
 							$writer->writeString($lines[$id]);
 							$writer->writeEndElement(); // Line
 						}
-						
+
 						unset($lines);
 					}
-					
+
 					if ($this->m_cardHolderAddress->getCity() !== null)
 					{
 						$writer->writeElementString("City", $this->m_cardHolderAddress->getCity());
 					}
-					
+
 					if ($this->m_cardHolderAddress->getState() !== null)
 					{
 						$writer->writeElementString("State", $this->m_cardHolderAddress->getState());
 					}
-					
+
 					if ($this->m_cardHolderAddress->getZipCode() !== null)
 					{
 						$writer->writeElementString("ZipCode", $this->m_cardHolderAddress->getZipCode());
 					}
-					
+
 					if ($this->m_cardHolderAddress->getCountry() !== null)
 					{
 						$writer->writeElementString("Country", $this->m_cardHolderAddress->getCountry());
 					}
-					
+
 					$writer->writeEndElement(); // Address
 				}
 
@@ -1395,74 +1395,74 @@ class CardEaseXML_Request {
 					($this->m_cardHolderPhoneNumbers !== null && count($this->m_cardHolderPhoneNumbers) !== 0))
 				{					
 					$writer->writeStartElement("Contact");
-					
+
 					if ($this->m_cardHolderEmailAddresses !== null && count($this->m_cardHolderEmailAddresses) !== 0)
 					{					
 						$writer->writeStartElement("EmailAddressList");
-						
+
 						for ($id = 0; $id < count($this->m_cardHolderEmailAddresses); $id++)
 						{							
 							$emailAddress = $this->m_cardHolderEmailAddresses[$id];							
-						
+
 							$writer->writeStartElement("EmailAddress");
 							$writer->writeAttributeString("id", $id + 1);
 							$writer->writeAttributeString("type", $emailAddress->getType());
 							$writer->writeString($emailAddress->getAddress());
 							$writer->writeEndElement(); // EmailAddress
-							
+
 							unset($emailAddress);
 						}
-						
+
 						$writer->writeEndElement(); // EmailAddressList
 					}
-					
+
 					if ($this->m_cardHolderName !== null && !$this->m_cardHolderName->isEmpty())
 					{						
 						$writer->writeStartElement("Name");
-						
+
 						if ($this->m_cardHolderName->getTitle() !== null)
 						{
 							$writer->writeElementString("Title", $this->m_cardHolderName->getTitle());
 						}
-						
+
 						if ($this->m_cardHolderName->getFirstName() !== null)
 						{
 							$writer->writeElementString("FirstName", $this->m_cardHolderName->getFirstName());
 						}
-						
+
 						if ($this->m_cardHolderName->getInitials() !== null)
 						{
 							$writer->writeElementString("Initials", $this->m_cardHolderName->getInitials());
 						}
-						
+
 						if ($this->m_cardHolderName->getLastName() !== null)
 						{
 							$writer->writeElementString("LastName", $this->m_cardHolderName->getLastName());
 						}
-						
+
 						$writer->writeEndElement(); // Name
 					}
-					
+
 					if ($this->m_cardHolderPhoneNumbers !== null && count($this->m_cardHolderPhoneNumbers) !== 0)
 					{					
 						$writer->writeStartElement("PhoneNumberList");
-						
+
 						for ($id = 0; $id < count($this->m_cardHolderPhoneNumbers); $id++)
 						{							
 							$phoneNumber = $this->m_cardHolderPhoneNumbers[$id];
-						
+
 							$writer->writeStartElement("PhoneNumber");
 							$writer->writeAttributeString("id", $id + 1);
 							$writer->writeAttributeString("type", $phoneNumber->getType());
 							$writer->writeString($phoneNumber->getNumber());
 							$writer->writeEndElement(); // PhoneNumber
-							
+
 							unset($phoneNumber);
 						}
-						
+
 						$writer->writeEndElement(); // PhoneNumbers
 					}
-					
+
 					$writer->writeEndElement(); // Contact
 				}
 
@@ -1471,37 +1471,37 @@ class CardEaseXML_Request {
 					|| $this->m_3DSecureTransactionStatus !== ThreeDSecureTransactionStatus_Empty)
 				{		
 					$writer->writeStartElement("ThreeDSecure");
-		
+
 					if ($this->m_3DSecureCardHolderEnrolled !== ThreeDSecureCardHolderEnrolled_Empty)
 					{
 						$writer->writeElementString("CardHolderEnrolled",
 							$this->m_3DSecureCardHolderEnrolled);
 					}
-		
+
 					if ($this->m_3DSecureECI !== null)
 					{
 						$writer->writeElementString("ECI", $this->m_3DSecureECI);
 					}
-		
+
 					if ($this->m_3DSecureIAV !== null)
 					{
 						$writer->writeStartElement("IAV");
-		
+
 						if ($this->m_3DSecureIAVAlgorithm !== null)
 						{
 							$writer->writeAttributeString("algorithm", $this->m_3DSecureIAVAlgorithm);
 						}
-		
+
 						$writer->writeAttributeString("format", $this->m_3DSecureIAVFormat);		
 						$writer->writeString($this->m_3DSecureIAV);
 						$writer->writeEndElement(); // IAV
 					}
-		
+
 					if ($this->m_3DSecureTransactionStatus !== ThreeDSecureTransactionStatus_Empty)
 					{
 						$writer->writeElementString("TransactionStatus", $this->m_3DSecureTransactionStatus);
 					}
-	
+
 					if ($this->m_3DSecureXID !== null)
 					{
 						$writer->writeStartElement("XID");
@@ -1509,10 +1509,10 @@ class CardEaseXML_Request {
 						$writer->writeString($this->m_3DSecureXID);
 						$writer->writeEndElement(); // XID
 					}
-		
+
 					$writer->writeEndElement(); // ThreeDSecure
 				}
-				
+
 				$writer->writeEndElement(); // CardDetails
 			}
 		}
@@ -3823,7 +3823,7 @@ class CardEaseXML_Request {
 			if (strlen($this->m_expiryDate) !== strlen($this->m_expiryDateFormat)) {
 				trigger_error("CardEaseXMLRequest: ExpiryDate does not conform to ExpiryDateFormat", E_USER_ERROR);
 			}
-			
+
 			// check format against date
 		}
 
@@ -3847,7 +3847,7 @@ class CardEaseXML_Request {
 			if (strlen($this->m_expiryDate) !== strlen($this->m_expiryDateFormat)) {
 				trigger_error("CardEaseXMLRequest: ExpiryDate does not conform to ExpiryDateFormat", E_USER_ERROR);
 			}
-			
+
 			// check format against date
 		}
 
@@ -3871,7 +3871,7 @@ class CardEaseXML_Request {
 			if (strlen($this->m_startDate) !== strlen($this->m_startDateFormat)) {
 				trigger_error("CardEaseXMLRequest: StartDate does not conform to StartDateFormat", E_USER_ERROR);
 			}
-			
+
 			// check format against date
 		}
 

--- a/client/src/Response.php
+++ b/client/src/Response.php
@@ -293,7 +293,7 @@ class Response {
 	/**
 	 * Constructs a new response and initialises all variables.
 	 */
-	function Response()
+	function __construct()
 	{
 		$this->m_addressResponseData = null;
 		$this->m_addressResult = VerificationResult_Empty;
@@ -477,7 +477,7 @@ class Response {
 			$this->m_originatingIPAddressRegion = $data;
 			return;
 		}
-		
+
 		if ($this->m_tagStack === array("RESPONSE", "TRANSACTIONDETAILS", "GEOIP", "ZIPCODE")) {
 			$this->m_originatingIPAddressZipCode = $data;
 			return;
@@ -631,7 +631,7 @@ class Response {
 			}		
 			return;
 		}
-		
+
 		if ($this->m_tagStack === array("RESPONSE", "TRANSACTIONDETAILS", "GEOIP", "CONTINENT")) {
 			$this->m_originatingIPAddressContinentAlpha2 = $attrs["ALPHA2"];
 			return;

--- a/client/src/ServerURL.php
+++ b/client/src/ServerURL.php
@@ -33,7 +33,7 @@ class ServerURL
 	 *	If zero is specified an infinite timeout is used.
 	 *	For most requests a timeout of 45 seconds (45000) is recommended.
 	 */
-	function ServerURL($url, $timeout) {
+	function __construct($url, $timeout) {
 		if ($timeout < 30000) {
 			trigger_error("CardEaseXMLCommunication: Timeout cannot be less than 30 seconds", E_USER_ERROR);
 		}


### PR DESCRIPTION
This library currently uses PHP4 Constructors in classes which trigger deprecation warnings in PHP 7+. This converts each of those to `__construct`. Automatic conversion using RectorPHP ✨